### PR TITLE
Change git pull to git fetch

### DIFF
--- a/EasyNovelAssistant/setup/Install-EasyNovelAssistant.bat
+++ b/EasyNovelAssistant/setup/Install-EasyNovelAssistant.bat
@@ -82,19 +82,21 @@ if exist %PORTABLE_GIT_DIR% (
 	cd > NUL
 
 	if exist .git\ (
-		echo git pull
-		git pull
+		echo Fetching and resetting repository to match origin
+		git fetch origin
+		git reset --hard origin/main
 	) else (
-		echo git clone %CLONE_URL% %APP_NAME_TEMP%
+		echo Cloning repository from %CLONE_URL% into %APP_NAME_TEMP%
 		git clone %CLONE_URL% %APP_NAME_TEMP%
 	)
 	if !errorlevel! neq 0 ( pause & popd & exit /b 1 )
 ) else (
 	if exist .git\ (
-		echo git pull
-		git pull
+		echo Fetching and resetting repository to match origin
+		git fetch origin
+		git reset --hard origin/main
 	) else (
-		echo git clone %CLONE_URL% %APP_NAME_TEMP%
+		echo Cloning repository from %CLONE_URL% into %APP_NAME_TEMP%
 		git clone %CLONE_URL% %APP_NAME_TEMP%
 	)
 	if !errorlevel! neq 0 ( pause & popd & exit /b 1 )


### PR DESCRIPTION
現在の最初のインストールのためにバッチファイルを実行すると、
ローカルに何もないにもかかわらず、git pull部分に「**already up to date**」エラーが表示され、
進行しない問題があります。

このバッチファイルは、ユーザーがgitリポジトリを体系的に管理するのではなく、
「_純粋に最新のコミットをダウンロード_」するのが本来の役割だと思われるため、
git pullに関連する部分を現在のローカルリポジトリの状態に関係なく
強制的に最新のコミットをダウンロードするように修正しました。

ぎこちない日本語の文章は、翻訳機を使ったからです。 ごめんなさい :(