### PR TITLE
fix(security): bump requests dependency

### DIFF
--- a/EasyNovelAssistant/setup/res/requirements.txt
+++ b/EasyNovelAssistant/setup/res/requirements.txt
@@ -1,4 +1,4 @@
-﻿requests==2.31.0
+﻿requests==2.34.2
 tkinterdnd2==0.3.0
 scipy==1.13.0
 watchdog==4.0.0


### PR DESCRIPTION
﻿## Summary
- Bump `requests` from 2.31.0 to 2.34.2.
- Keeps the existing pinned dependency style.

## Security
`pip-audit` reports three known vulnerabilities for requests 2.31.0:
- CVE-2024-35195
- CVE-2024-47081
- CVE-2026-25645

After the bump, `pip-audit -r EasyNovelAssistant\setup\res\requirements.txt --format json` reports no known vulnerabilities.

## Validation
- `pip-audit -r EasyNovelAssistant\setup\res\requirements.txt --format json`
- `python -m py_compile EasyNovelAssistant\src\easy_novel_assistant.py EasyNovelAssistant\src\kobold_cpp.py EasyNovelAssistant\src\style_bert_vits2.py`

Note: Python 3.14 emits an existing SyntaxWarning in `kobold_cpp.py` for a Windows path escape sequence; this PR does not touch that file.
